### PR TITLE
Bug fix: Set the current query start time for each statement

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	gms "github.com/dolthub/go-mysql-server/sql"
 	"io"
+	"time"
 )
 
 var _ driver.Conn = (*DoltConn)(nil)
@@ -74,6 +75,9 @@ func (d *DoltConn) Prepare(query string) (driver.Stmt, error) {
 		}
 	}
 
+	// Reuse the same ctx instance, but update the QueryTime to the current time. Since statements are
+	// executed serially on a connection, it's safe to reuse the same ctx instance and update the time.
+	d.gmsCtx.SetQueryTime(time.Now())
 	return &doltStmt{
 		query:  query,
 		se:     d.se,


### PR DESCRIPTION
When using `dolthub/driver`, every `doltStmt` is assigned the shared `ctx` instance owned by the `doltConn`. This resulted in every statement having a QueryStartTime equal to when the connection was created. This change updates the `doltStmt` creation code to assign the latest QueryStartTime when a new `doltStmt` is created. 

Fixes: https://github.com/dolthub/dolt/issues/6700