### PR TITLE
Add clientfoundrows DSN parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ the commit log.
 commitname - The name of the committer seen in the dolt commit log
 commitemail - The email of the committer seen in the dolt commit log
 database - The initial database to connect to
+multistatements - If set to true, allows multiple statements in one query
+clientfoundrows - If set to true, returns the number of matching rows instead of the number of changed rows in UPDATE queries
 ```
 
 #### Example DSN

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 
 # Dolt Database Driver
 
-This package provides a driver to be used with the database/sql package for database access in Golang.
+This package provides a database/sql-compatible driver for [embedding dolt inside a Go application](https://www.dolthub.com/blog/2022-07-25-embedded/).
+It allows you to access local dolt databases via the file system, akin to SQLite.
 For details of the database/sql package see [this tutorial](https://go.dev/doc/tutorial/database-access).
 Below I will cover things that are specific to using dolt with this database driver.
 

--- a/data_source_test.go
+++ b/data_source_test.go
@@ -1,8 +1,9 @@
 package embedded
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseDataSource(t *testing.T) {
@@ -24,13 +25,14 @@ func TestParseDataSource(t *testing.T) {
 		},
 		{
 			name:              "unix dsn test",
-			dsn:               `file:///Users/brian/datasets/test?commitname=Billy%20Batson&commitemail=shazam@gmail.com&database=hostedapidb&multiStatements=true`,
+			dsn:               `file:///Users/brian/datasets/test?commitname=Billy%20Batson&commitemail=shazam@gmail.com&database=hostedapidb&multiStatements=true&clientFoundRows=true`,
 			expectedDirectory: `/Users/brian/datasets/test`,
 			expectedParams: map[string][]string{
 				CommitNameParam:      {"Billy Batson"},
 				CommitEmailParam:     {"shazam@gmail.com"},
 				DatabaseParam:        {"hostedapidb"},
 				MultiStatementsParam: {"true"},
+				ClientFoundRowsParam: {"true"},
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds a DSN parameter for setting the `CLIENT_FOUND_ROWS` capability.

I also took the liberty of updating the description in the README a bit, as it wasn't clear to me originally what the purpose of this package was.

Fixes #21.
