### PR TITLE
Ensure implicit transactions are committed

### DIFF
--- a/result.go
+++ b/result.go
@@ -1,9 +1,8 @@
 package embedded
 
 import (
-	"io"
-
 	"database/sql/driver"
+	"io"
 
 	gms "github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
@@ -37,6 +36,10 @@ func newResult(gmsCtx *gms.Context, sch gms.Schema, rowItr gms.RowIter) *doltRes
 				last = int64(res.InsertID)
 			}
 		}
+	}
+
+	if err := rowItr.Close(gmsCtx); err != nil {
+		return &doltResult{err: err}
 	}
 
 	return &doltResult{

--- a/smoke_test.go
+++ b/smoke_test.go
@@ -171,8 +171,5 @@ func initializeTestDatabaseConnection(t *testing.T, clientFoundRows bool) (conn 
 	_, err = res.RowsAffected()
 	require.NoError(t, err)
 
-	_, err = conn.ExecContext(ctx, "commit;")
-	require.NoError(t, err)
-
 	return conn, cleanUpFunc
 }


### PR DESCRIPTION
This PR adds a missing `Close` call on the row iterator used by `doltStmt.Exec`, ensuring that the implicit transaction associated with the query is committed.

Also removed an unnecessary commit from the smoke tests which was masking the issue.

Fixes #23