### PR TITLE
[auto-bump] dolt @ 0ed8c4d7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.6
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/dolthub/dolt/go v0.40.5-0.20260407195738-cd75bbcd45f9
+	github.com/dolthub/dolt/go v0.40.5-0.20260408193519-0ed8c4d76858
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260407181810-b4571952d446
 	github.com/dolthub/vitess v0.0.0-20260309181228-a99af9c518ab

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 h1:I
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12/go.mod h1:rN7X8BHwkjPcfMQQ2QTAq/xM3leUSGLfb+1Js7Y6TVo=
 github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP44=
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
-github.com/dolthub/dolt/go v0.40.5-0.20260407195738-cd75bbcd45f9 h1:7os+3TYbdFZu4hs7M0eEz53s6lnKvw9gPIOEUYMlRdg=
-github.com/dolthub/dolt/go v0.40.5-0.20260407195738-cd75bbcd45f9/go.mod h1:+f0P8deSjIKUYslIo7WIKzeU//b3wecTCyJIGpYFXGg=
+github.com/dolthub/dolt/go v0.40.5-0.20260408193519-0ed8c4d76858 h1:YvFH2qH7+68BsnheU5wUNn6LvwPcRHVlz52zM9i0+PM=
+github.com/dolthub/dolt/go v0.40.5-0.20260408193519-0ed8c4d76858/go.mod h1:+f0P8deSjIKUYslIo7WIKzeU//b3wecTCyJIGpYFXGg=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 h1:JShhbqMw26nKx3pqqu/cFxOpzBkN+4elVhzuUfgDw2k=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers v1.13.0-dh.1 h1:OWJdaPep22N52O/0xsUevxJ6Qfw1M2txCjZPOdjXybE=


### PR DESCRIPTION
Auto-bump of `dolt` to `0ed8c4d76858a4978d881baffb29be8f419a618f` (triggered via `repository_dispatch`).

- This PR was created automatically.
- Older auto-bump PRs for the same dependency may be auto-closed if their CI is complete and acceptable.