### PR TITLE
[auto-bump] dolt @ 608f54a5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.25.6
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/dolthub/dolt/go v0.40.5-0.20260410214018-29e9eb64790a
+	github.com/dolthub/dolt/go v0.40.5-0.20260413152636-608f54a53b76
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
-	github.com/dolthub/go-mysql-server v0.20.1-0.20260408230922-6d219f1e7c8d
+	github.com/dolthub/go-mysql-server v0.20.1-0.20260412215059-d7fc9477f4b7
 	github.com/dolthub/vitess v0.0.0-20260309181228-a99af9c518ab
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/stretchr/testify v1.11.1
@@ -67,7 +67,7 @@ require (
 	github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 // indirect
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 // indirect
 	github.com/dolthub/fslock v0.0.3 // indirect
-	github.com/dolthub/go-icu-regex v0.0.0-20250916051405-78a38d478790 // indirect
+	github.com/dolthub/go-icu-regex v0.0.0-20260412212219-49724d547866 // indirect
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 // indirect
 	github.com/dolthub/ishell v0.0.0-20240701202509-2b217167d718 // indirect
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 // indirect

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 h1:I
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12/go.mod h1:rN7X8BHwkjPcfMQQ2QTAq/xM3leUSGLfb+1Js7Y6TVo=
 github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP44=
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
-github.com/dolthub/dolt/go v0.40.5-0.20260410214018-29e9eb64790a h1:4QB5axwOKEUw2m2ngSScwdhPKs2ruWmZPB+Jyu8SY0A=
-github.com/dolthub/dolt/go v0.40.5-0.20260410214018-29e9eb64790a/go.mod h1:tuNFIG4p27J8ZIm4afDJwUZlrJXbNz3fyRyOSw2Ogx8=
+github.com/dolthub/dolt/go v0.40.5-0.20260413152636-608f54a53b76 h1:LRl83r0R1a/SpXN2eT6P6/HN+PBz5ACW4BGHeje/sWM=
+github.com/dolthub/dolt/go v0.40.5-0.20260413152636-608f54a53b76/go.mod h1:herP1qJMjcHmk0i4211oIP8WEfKWIk9aXEYJ9/ha59M=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 h1:JShhbqMw26nKx3pqqu/cFxOpzBkN+4elVhzuUfgDw2k=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers v1.13.0-dh.1 h1:OWJdaPep22N52O/0xsUevxJ6Qfw1M2txCjZPOdjXybE=
@@ -341,10 +341,10 @@ github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1G
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2/go.mod h1:mIEZOHnFx4ZMQeawhw9rhsj+0zwQj7adVsnBX7t+eKY=
 github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
-github.com/dolthub/go-icu-regex v0.0.0-20250916051405-78a38d478790 h1:zxMsH7RLiG+dlZ/y0LgJHTV26XoiSJcuWq+em6t6VVc=
-github.com/dolthub/go-icu-regex v0.0.0-20250916051405-78a38d478790/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
-github.com/dolthub/go-mysql-server v0.20.1-0.20260408230922-6d219f1e7c8d h1:CnjGGh1Saafw+tRf9+xMtMHLw8hu5LJIfSqbTmGzRuk=
-github.com/dolthub/go-mysql-server v0.20.1-0.20260408230922-6d219f1e7c8d/go.mod h1:SQws7iFFL5fNxjGbl6xyWNBz3DWTReGBegApANmnwhM=
+github.com/dolthub/go-icu-regex v0.0.0-20260412212219-49724d547866 h1:U6gSf5I0e6h6GP1/5Sa7D2lWW1CWfcVPtY5wkyHq6jY=
+github.com/dolthub/go-icu-regex v0.0.0-20260412212219-49724d547866/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260412215059-d7fc9477f4b7 h1:FIjSz+BuQD/ziIV07Md1I5RGtFxkjB4HcCVqDTYYrU0=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260412215059-d7fc9477f4b7/go.mod h1:vcp9FtFdeSI2vTld+6HlouLKKaI8aF8Ey4wvYeMUqVg=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20240701202509-2b217167d718 h1:lT7hE5k+0nkBdj/1UOSFwjWpNxf+LCApbRHgnCA17XE=


### PR DESCRIPTION
Auto-bump of `dolt` to `608f54a53b764c981bad4ba2d692e1f293ebe4f4` (triggered via `repository_dispatch`).

- This PR was created automatically.
- Older auto-bump PRs for the same dependency may be auto-closed if their CI is complete and acceptable.