### PR TITLE
[auto-bump] dolt @ 250fcf57

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.6
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/dolthub/dolt/go v0.40.5-0.20260414235148-1aae88a7e7b9
+	github.com/dolthub/dolt/go v0.40.5-0.20260415052817-250fcf57cd3d
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260412215059-d7fc9477f4b7
 	github.com/dolthub/vitess v0.0.0-20260309181228-a99af9c518ab

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 h1:I
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12/go.mod h1:rN7X8BHwkjPcfMQQ2QTAq/xM3leUSGLfb+1Js7Y6TVo=
 github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP44=
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
-github.com/dolthub/dolt/go v0.40.5-0.20260414235148-1aae88a7e7b9 h1:6OQmYoufcvOouWF4QQ/mQnM4Ms6TMwBrw7j/Lea7Wl8=
-github.com/dolthub/dolt/go v0.40.5-0.20260414235148-1aae88a7e7b9/go.mod h1:tixrAzOFdLCGmRMJtbCu3wMmbHVKYiQkyVmpbURt/oM=
+github.com/dolthub/dolt/go v0.40.5-0.20260415052817-250fcf57cd3d h1:/R02kIvxFq3lIOcAMB6wUMRaMhBZ58VFe4mg7vYaip0=
+github.com/dolthub/dolt/go v0.40.5-0.20260415052817-250fcf57cd3d/go.mod h1:tixrAzOFdLCGmRMJtbCu3wMmbHVKYiQkyVmpbURt/oM=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 h1:JShhbqMw26nKx3pqqu/cFxOpzBkN+4elVhzuUfgDw2k=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=


### PR DESCRIPTION
Auto-bump of `dolt` to `250fcf57cd3d684751534f03acc21666a8deb2d8` (triggered via `repository_dispatch`).

- This PR was created automatically.
- Older auto-bump PRs for the same dependency may be auto-closed if their CI is complete and acceptable.