### PR TITLE
[auto-bump] dolt @ d68d8d67

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.6
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/dolthub/dolt/go v0.40.5-0.20260420203214-bb6bdd65b3c4
+	github.com/dolthub/dolt/go v0.40.5-0.20260421205745-d68d8d674c5f
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260415223525-cbe3a4007b97
 	github.com/dolthub/vitess v0.0.0-20260309181228-a99af9c518ab

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 h1:I
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12/go.mod h1:rN7X8BHwkjPcfMQQ2QTAq/xM3leUSGLfb+1Js7Y6TVo=
 github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP44=
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
-github.com/dolthub/dolt/go v0.40.5-0.20260420203214-bb6bdd65b3c4 h1:9X2mCqdBmlRMcToHOreVQiunJwLD1PrAvpYeXzgs03c=
-github.com/dolthub/dolt/go v0.40.5-0.20260420203214-bb6bdd65b3c4/go.mod h1:EajXO8JKBVzgNG21QqxYnKDtjj5vu+20KGRO1mUa8og=
+github.com/dolthub/dolt/go v0.40.5-0.20260421205745-d68d8d674c5f h1:BzonbarO4AsdcL/Rsm8yNWlwZoQMzv+CQMGUT3GLb74=
+github.com/dolthub/dolt/go v0.40.5-0.20260421205745-d68d8d674c5f/go.mod h1:EajXO8JKBVzgNG21QqxYnKDtjj5vu+20KGRO1mUa8og=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 h1:JShhbqMw26nKx3pqqu/cFxOpzBkN+4elVhzuUfgDw2k=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=


### PR DESCRIPTION
Auto-bump of `dolt` to `d68d8d674c5f1c346d7b0b5a83579b69ee955dda` (triggered via `repository_dispatch`).

- This PR was created automatically.
- Older auto-bump PRs for the same dependency may be auto-closed if their CI is complete and acceptable.