### PR TITLE
[auto-bump] dolt @ f0a96b0a

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/dolthub/dolt/go v0.40.5-0.20260422221605-73fcb4a868c2
+	github.com/dolthub/dolt/go v0.40.5-0.20260423164703-f0a96b0a33f3
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260422200044-972069de98a8
 	github.com/dolthub/vitess v0.0.0-20260422060906-f6f5b5573b7b

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 h1:I
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12/go.mod h1:rN7X8BHwkjPcfMQQ2QTAq/xM3leUSGLfb+1Js7Y6TVo=
 github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP44=
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
-github.com/dolthub/dolt/go v0.40.5-0.20260422221605-73fcb4a868c2 h1:GwxKqkhdzEe6kU6YrZ6ffRBbaUmjv6c2TEBbzwZnJSI=
-github.com/dolthub/dolt/go v0.40.5-0.20260422221605-73fcb4a868c2/go.mod h1:RS3HguvuVo64ikGtKfdHS2QZegQOkp8GpJ0OzWdw6dU=
+github.com/dolthub/dolt/go v0.40.5-0.20260423164703-f0a96b0a33f3 h1:LsK/CxlWqcz4kInTET03SlzMvYARPJ55lKy2HQ4T95A=
+github.com/dolthub/dolt/go v0.40.5-0.20260423164703-f0a96b0a33f3/go.mod h1:RS3HguvuVo64ikGtKfdHS2QZegQOkp8GpJ0OzWdw6dU=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 h1:JShhbqMw26nKx3pqqu/cFxOpzBkN+4elVhzuUfgDw2k=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=


### PR DESCRIPTION
Auto-bump of `dolt` to `f0a96b0a33f35ae599f1f607b3e3c805805160a6` (triggered via `repository_dispatch`).

- This PR was created automatically.
- Older auto-bump PRs for the same dependency may be auto-closed if their CI is complete and acceptable.