### PR TITLE
rows: implement RowsColumnTypeDatabaseTypeName for doltRows and doltMultiRows

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -36,12 +36,20 @@ type doltMultiRows struct {
 }
 
 var _ driver.RowsNextResultSet = (*doltMultiRows)(nil)
+var _ driver.RowsColumnTypeDatabaseTypeName = (*doltMultiRows)(nil)
 
 func (d *doltMultiRows) Columns() []string {
 	if d.currentRowSet == nil {
 		return nil
 	}
 	return d.currentRowSet.Columns()
+}
+
+func (d *doltMultiRows) ColumnTypeDatabaseTypeName(i int) string {
+	if d.currentRowSet == nil {
+		return ""
+	}
+	return d.currentRowSet.ColumnTypeDatabaseTypeName(i)
 }
 
 // Close implements the driver.Rows interface. When Close is called on
@@ -124,6 +132,15 @@ type doltRows struct {
 }
 
 var _ driver.Rows = (*doltRows)(nil)
+var _ driver.RowsColumnTypeDatabaseTypeName = (*doltRows)(nil)
+
+// ColumnTypeDatabaseTypeName returns the database system type name for column i.
+func (rows *doltRows) ColumnTypeDatabaseTypeName(i int) string {
+	if i >= 0 && i < len(rows.sch) {
+		return rows.sch[i].Type.String()
+	}
+	return ""
+}
 
 // Columns returns the names of the columns. The number of columns of the result is inferred from the length of the
 // slice. If a particular column name isn't known, an empty string should be returned for that entry.

--- a/rows_test.go
+++ b/rows_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package embedded
+
+import (
+	"testing"
+
+	gms "github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDoltRowsColumnTypeDatabaseTypeName(t *testing.T) {
+	sch := gms.Schema{
+		&gms.Column{Name: "pk", Type: types.Int64},
+		&gms.Column{Name: "name", Type: types.Text},
+	}
+	rows := &doltRows{sch: sch}
+
+	require.Equal(t, sch[0].Type.String(), rows.ColumnTypeDatabaseTypeName(0))
+	require.Equal(t, sch[1].Type.String(), rows.ColumnTypeDatabaseTypeName(1))
+	require.Equal(t, "", rows.ColumnTypeDatabaseTypeName(-1))
+	require.Equal(t, "", rows.ColumnTypeDatabaseTypeName(2))
+}
+
+func TestDoltMultiRowsColumnTypeDatabaseTypeName(t *testing.T) {
+	t.Run("no current row set", func(t *testing.T) {
+		rows := &doltMultiRows{}
+		require.Equal(t, "", rows.ColumnTypeDatabaseTypeName(0))
+	})
+
+	t.Run("delegates to current row set", func(t *testing.T) {
+		sch := gms.Schema{
+			&gms.Column{Name: "v", Type: types.Float64},
+		}
+		rows := &doltMultiRows{
+			currentRowSet: &doltRows{sch: sch},
+		}
+
+		require.Equal(t, sch[0].Type.String(), rows.ColumnTypeDatabaseTypeName(0))
+		require.Equal(t, "", rows.ColumnTypeDatabaseTypeName(1))
+	})
+}


### PR DESCRIPTION
## Summary

`database/sql/driver` defines the optional `RowsColumnTypeDatabaseTypeName` interface:

```go
type RowsColumnTypeDatabaseTypeName interface {
    Rows
    ColumnTypeDatabaseTypeName(index int) string
}
```

When a driver implements this interface, `database/sql` (and any library built on top of it) can retrieve the original SQL type name for each column — for example `INT`, `BIGINT UNSIGNED`, `DECIMAL(10,2)`, `VARCHAR(255)`, `TIMESTAMP(6)` — without having to infer the type from the Go value alone.

`doltRows` already holds a `gms.Schema` whose `Type.String()` method returns exactly these MySQL-compatible type names, so implementing the interface is straightforward and zero-cost.

## Changes

- `doltRows` now implements `driver.RowsColumnTypeDatabaseTypeName` via `ColumnTypeDatabaseTypeName(i int) string`, which returns `rows.sch[i].Type.String()`.
- `doltMultiRows` delegates to the current `*doltRows`.
- Compile-time interface checks (`var _ driver.RowsColumnTypeDatabaseTypeName = (*doltRows)(nil)`) are added for both types.

## Testing

Existing tests continue to pass. The new behaviour is exercised by any caller that uses `(*sql.Rows).ColumnTypeDatabaseTypeName`.