### PR TITLE
[auto-bump] dolt @ 0e49e641

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/dolthub/dolt/go v0.40.5-0.20260507231811-577c666cc34c
+	github.com/dolthub/dolt/go v0.40.5-0.20260513180943-0e49e6419406
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260507202550-43d6daf5958b
 	github.com/dolthub/vitess v0.0.0-20260505163811-77e5224be390

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 h1:I
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12/go.mod h1:rN7X8BHwkjPcfMQQ2QTAq/xM3leUSGLfb+1Js7Y6TVo=
 github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP44=
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
-github.com/dolthub/dolt/go v0.40.5-0.20260507231811-577c666cc34c h1:MoFZR1KMWEft1wAI4p+B6AjofD7Y5frOPNLM+747EUY=
-github.com/dolthub/dolt/go v0.40.5-0.20260507231811-577c666cc34c/go.mod h1:zQgkmBI5uIRpzo+liO3Q6by+rcLWGcvyJhAAI/rmkHE=
+github.com/dolthub/dolt/go v0.40.5-0.20260513180943-0e49e6419406 h1:VBqHCdCwZEqkXalswf5CvDvcIQ8ZVmgoqx8Mz+PXsXY=
+github.com/dolthub/dolt/go v0.40.5-0.20260513180943-0e49e6419406/go.mod h1:zQgkmBI5uIRpzo+liO3Q6by+rcLWGcvyJhAAI/rmkHE=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 h1:JShhbqMw26nKx3pqqu/cFxOpzBkN+4elVhzuUfgDw2k=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=


### PR DESCRIPTION
Auto-bump of `dolt` to `0e49e64194063dd9d10a672ef370a06b76aaff2c` (triggered via `repository_dispatch`).

- This PR was created automatically.
- Older auto-bump PRs for the same dependency may be auto-closed if their CI is complete and acceptable.