### PR TITLE
[auto-bump] dolt @ 1ad5024c

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/dolthub/dolt/go v0.40.5-0.20260515074142-26ea075f5819
+	github.com/dolthub/dolt/go v0.40.5-0.20260515163843-1ad5024c38d9
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260515064916-99021d8ca6e8
 	github.com/dolthub/vitess v0.0.0-20260505163811-77e5224be390

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 h1:I
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12/go.mod h1:rN7X8BHwkjPcfMQQ2QTAq/xM3leUSGLfb+1Js7Y6TVo=
 github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP44=
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
-github.com/dolthub/dolt/go v0.40.5-0.20260515074142-26ea075f5819 h1:TbsnIgsMvE1Lq/QljBgQrkXUnP1slojqHXcpHDZDp8g=
-github.com/dolthub/dolt/go v0.40.5-0.20260515074142-26ea075f5819/go.mod h1:MzRHrmsinKMqu26csnYqXzoktHHF0jQeIqlEh7qzHsE=
+github.com/dolthub/dolt/go v0.40.5-0.20260515163843-1ad5024c38d9 h1:tpGwufwQghkMWev27mpaIH5NZ7Mukz7Iccb5jU5z4jE=
+github.com/dolthub/dolt/go v0.40.5-0.20260515163843-1ad5024c38d9/go.mod h1:MzRHrmsinKMqu26csnYqXzoktHHF0jQeIqlEh7qzHsE=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 h1:JShhbqMw26nKx3pqqu/cFxOpzBkN+4elVhzuUfgDw2k=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=


### PR DESCRIPTION
Auto-bump of `dolt` to `1ad5024c38d93ded100dad17d4f6f078b933c4a9` (triggered via `repository_dispatch`).

- This PR was created automatically.
- Older auto-bump PRs for the same dependency may be auto-closed if their CI is complete and acceptable.