### PR TITLE
[auto-bump] dolt @ 67780a3f

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/dolthub/dolt/go v0.40.5-0.20260526201042-36c11fe96d61
+	github.com/dolthub/dolt/go v0.40.5-0.20260527155818-67780a3f68cf
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260526174314-044bab1ab87a
 	github.com/dolthub/vitess v0.0.0-20260521165014-2fdb4300ae8d

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 h1:I
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12/go.mod h1:rN7X8BHwkjPcfMQQ2QTAq/xM3leUSGLfb+1Js7Y6TVo=
 github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP44=
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
-github.com/dolthub/dolt/go v0.40.5-0.20260526201042-36c11fe96d61 h1:8+06NjwKqYwfAY8swzugtMrNXrn9VW6UcG5/XVi1z7o=
-github.com/dolthub/dolt/go v0.40.5-0.20260526201042-36c11fe96d61/go.mod h1:/UhL72ogXt/zf6xZfqalGvdCQDd3BAI9sIjpbUvLg0A=
+github.com/dolthub/dolt/go v0.40.5-0.20260527155818-67780a3f68cf h1:zWu8aRMa++ScEJKzn9xaHioT7CFDoWS900FXD4G6vS8=
+github.com/dolthub/dolt/go v0.40.5-0.20260527155818-67780a3f68cf/go.mod h1:/UhL72ogXt/zf6xZfqalGvdCQDd3BAI9sIjpbUvLg0A=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 h1:JShhbqMw26nKx3pqqu/cFxOpzBkN+4elVhzuUfgDw2k=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=


### PR DESCRIPTION
Auto-bump of `dolt` to `67780a3f68cfbcbf682a04c9e487e3ff956e25a0` (triggered via `repository_dispatch`).

- This PR was created automatically.
- Older auto-bump PRs for the same dependency may be auto-closed if their CI is complete and acceptable.