### PR TITLE
[auto-bump] dolt @ 1bf53322

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/dolthub/dolt/go v0.40.5-0.20260605195633-5078a2d5ea45
+	github.com/dolthub/dolt/go v0.40.5-0.20260605230755-1bf533220ab0
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260605175459-433dbaebc97f
 	github.com/dolthub/vitess v0.0.0-20260604210335-0893abc80542

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 h1:I
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12/go.mod h1:rN7X8BHwkjPcfMQQ2QTAq/xM3leUSGLfb+1Js7Y6TVo=
 github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP44=
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
-github.com/dolthub/dolt/go v0.40.5-0.20260605195633-5078a2d5ea45 h1:HFMN5Bb+OiAoN0r5sDUAL8rc9lyWKBl0GiOZWn7BEwA=
-github.com/dolthub/dolt/go v0.40.5-0.20260605195633-5078a2d5ea45/go.mod h1:XwB+rt1QwszYYQIqFzIh6GyI5wUCWsmcgmGC/noAEcc=
+github.com/dolthub/dolt/go v0.40.5-0.20260605230755-1bf533220ab0 h1:oPg5f5bYFy5x7Ws2qtVG7wiva96cIh9SFg7nrC4n7QA=
+github.com/dolthub/dolt/go v0.40.5-0.20260605230755-1bf533220ab0/go.mod h1:XwB+rt1QwszYYQIqFzIh6GyI5wUCWsmcgmGC/noAEcc=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 h1:JShhbqMw26nKx3pqqu/cFxOpzBkN+4elVhzuUfgDw2k=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=


### PR DESCRIPTION
Auto-bump of `dolt` to `1bf533220ab04e6afccee64f20ff8d0f5b92202e` (triggered via `repository_dispatch`).

- This PR was created automatically.
- Older auto-bump PRs for the same dependency may be auto-closed if their CI is complete and acceptable.