### PR TITLE
[auto-bump] dolt @ 351ed131

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/dolthub/dolt/go v0.40.5-0.20260608234721-b5d174ccedd0
+	github.com/dolthub/dolt/go v0.40.5-0.20260609181119-351ed131f9bd
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260608231025-6579b6af9de2
 	github.com/dolthub/vitess v0.0.0-20260604210335-0893abc80542

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 h1:I
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12/go.mod h1:rN7X8BHwkjPcfMQQ2QTAq/xM3leUSGLfb+1Js7Y6TVo=
 github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP44=
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
-github.com/dolthub/dolt/go v0.40.5-0.20260608234721-b5d174ccedd0 h1:6C7xRjj/mT0V+i3L52PzwYpMncqMMXA028BCDiPPCoQ=
-github.com/dolthub/dolt/go v0.40.5-0.20260608234721-b5d174ccedd0/go.mod h1:qUI6QdFuKRbg4/7U+gNrm1dcuH3ZpCSJNgT6GnZ2fTQ=
+github.com/dolthub/dolt/go v0.40.5-0.20260609181119-351ed131f9bd h1:FZcbgW/isBi4YwJideF4AeQIZ199Un2q5XU01OF3v/k=
+github.com/dolthub/dolt/go v0.40.5-0.20260609181119-351ed131f9bd/go.mod h1:qUI6QdFuKRbg4/7U+gNrm1dcuH3ZpCSJNgT6GnZ2fTQ=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 h1:JShhbqMw26nKx3pqqu/cFxOpzBkN+4elVhzuUfgDw2k=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=


### PR DESCRIPTION
Auto-bump of `dolt` to `351ed131f9bdd621cb2f7886d123f80204e86194` (triggered via `repository_dispatch`).

- This PR was created automatically.
- Older auto-bump PRs for the same dependency may be auto-closed if their CI is complete and acceptable.