### PR TITLE
[auto-bump] dolt @ feba4a82

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/dolthub/dolt/go v0.40.5-0.20260624000019-4f8184183c4e
+	github.com/dolthub/dolt/go v0.40.5-0.20260624213831-feba4a825720
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260623224402-eee792a22ff6
 	github.com/dolthub/vitess v0.0.0-20260617012411-2f308f6cdc23

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 h1:I
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12/go.mod h1:rN7X8BHwkjPcfMQQ2QTAq/xM3leUSGLfb+1Js7Y6TVo=
 github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP44=
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
-github.com/dolthub/dolt/go v0.40.5-0.20260624000019-4f8184183c4e h1:EydVoxtynei1yZ6vCWKFKU9XuIY3awlG5+K4qSdGUm8=
-github.com/dolthub/dolt/go v0.40.5-0.20260624000019-4f8184183c4e/go.mod h1:Ag5UOmZsjACE4bx1AmahSCf0HiOO4avxvyOQebVGKXM=
+github.com/dolthub/dolt/go v0.40.5-0.20260624213831-feba4a825720 h1:SHrZF+kl97eA7xUUelGC0QKXpxmfMlU3uMR7ATDTe9w=
+github.com/dolthub/dolt/go v0.40.5-0.20260624213831-feba4a825720/go.mod h1:Ag5UOmZsjACE4bx1AmahSCf0HiOO4avxvyOQebVGKXM=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 h1:JShhbqMw26nKx3pqqu/cFxOpzBkN+4elVhzuUfgDw2k=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=


### PR DESCRIPTION
Auto-bump of `dolt` to `feba4a825720acba2b4d6650eb224116b22e19fd` (triggered via `repository_dispatch`).

- This PR was created automatically.
- Older auto-bump PRs for the same dependency may be auto-closed if their CI is complete and acceptable.