### PR TITLE
[auto-bump] dolt @ d286e892

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/dolthub/dolt/go v0.40.5-0.20260624222156-2365a9d671e8
+	github.com/dolthub/dolt/go v0.40.5-0.20260625164551-d286e8926c62
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260624214512-1199bbe99f4e
 	github.com/dolthub/vitess v0.0.0-20260617012411-2f308f6cdc23

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 h1:I
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12/go.mod h1:rN7X8BHwkjPcfMQQ2QTAq/xM3leUSGLfb+1Js7Y6TVo=
 github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP44=
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
-github.com/dolthub/dolt/go v0.40.5-0.20260624222156-2365a9d671e8 h1:SRuqRA7bz+gE226rg0viON4cdpkMWSRXioabILKdU5A=
-github.com/dolthub/dolt/go v0.40.5-0.20260624222156-2365a9d671e8/go.mod h1:r7xBooDNCBjsYky+5gz8xs9twK7zqnfm8MfK8+B4qnQ=
+github.com/dolthub/dolt/go v0.40.5-0.20260625164551-d286e8926c62 h1:7QkEs8H8NUsRD3PcbOM4N8bXX+9Pc301OEaiwGBevHo=
+github.com/dolthub/dolt/go v0.40.5-0.20260625164551-d286e8926c62/go.mod h1:r7xBooDNCBjsYky+5gz8xs9twK7zqnfm8MfK8+B4qnQ=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 h1:JShhbqMw26nKx3pqqu/cFxOpzBkN+4elVhzuUfgDw2k=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=


### PR DESCRIPTION
Auto-bump of `dolt` to `d286e8926c625e5263678e71bf3a5b20ee61ab2b` (triggered via `repository_dispatch`).

- This PR was created automatically.
- Older auto-bump PRs for the same dependency may be auto-closed if their CI is complete and acceptable.