### PR TITLE
[auto-bump] dolt @ 49b81b6b

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.26.2
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/dolthub/dolt/go v0.40.5-0.20260715222552-6bea62fec1d6
-	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
+	github.com/dolthub/dolt/go v0.40.5-0.20260717053635-49b81b6b4bda
+	github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260715210958-36c4fed9afa6
 	github.com/dolthub/vitess v0.0.0-20260624214226-81d034e0fde8
 	github.com/go-sql-driver/mysql v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -333,10 +333,10 @@ github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 h1:I
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12/go.mod h1:rN7X8BHwkjPcfMQQ2QTAq/xM3leUSGLfb+1Js7Y6TVo=
 github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP44=
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
-github.com/dolthub/dolt/go v0.40.5-0.20260715222552-6bea62fec1d6 h1:abnk5UJQMJue6ZHFl4VIOUWSMV3/mjq/a3tAyLhVrFI=
-github.com/dolthub/dolt/go v0.40.5-0.20260715222552-6bea62fec1d6/go.mod h1:NeIUHB089JzLdjA37lExTUW0oOj9ck5LPTpRMquVpb4=
-github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 h1:JShhbqMw26nKx3pqqu/cFxOpzBkN+4elVhzuUfgDw2k=
-github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
+github.com/dolthub/dolt/go v0.40.5-0.20260717053635-49b81b6b4bda h1:oMZjeO7KJKV2FGuSNsP2tJXWOz0JjOPa7xVNoz2+20o=
+github.com/dolthub/dolt/go v0.40.5-0.20260717053635-49b81b6b4bda/go.mod h1:3y+3STq+7aushqr4sLOW3fzRC+TT1xD0LeaYDbmvaEY=
+github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4 h1:0mg9QEFdkkBwJMxvz1tCjHYmfG2iIC6aShj1InDq9/M=
+github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2/go.mod h1:mIEZOHnFx4ZMQeawhw9rhsj+0zwQj7adVsnBX7t+eKY=
 github.com/dolthub/fslock v0.0.5 h1:QoXhBhgY1oumHE26qyE7tgmXUT8qjJwxsIzo54O/B/k=


### PR DESCRIPTION
Auto-bump of `dolt` to `49b81b6b4bdaddc9d511c80405c3451183974951` (triggered via `repository_dispatch`).

- This PR was created automatically.
- Older auto-bump PRs for the same dependency may be auto-closed if their CI is complete and acceptable.