### PR TITLE
[auto-bump] dolt @ eb949f42

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/dolthub/dolt/go v0.40.5-0.20260827231312-233f3eb5f895
+	github.com/dolthub/dolt/go v0.40.5-0.20260828012016-eb949f4275a9
 	github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260827221007-116970748291
 	github.com/dolthub/vitess v0.0.0-20260819175407-19559ab533b7

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 h1:I
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12/go.mod h1:rN7X8BHwkjPcfMQQ2QTAq/xM3leUSGLfb+1Js7Y6TVo=
 github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP44=
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
-github.com/dolthub/dolt/go v0.40.5-0.20260827231312-233f3eb5f895 h1:AsOmM9H/d9z00vAr+xyaJbSLPAQk8dii85GmOm7k0i0=
-github.com/dolthub/dolt/go v0.40.5-0.20260827231312-233f3eb5f895/go.mod h1:LfsOnHLbroYX8R6k1c5QcwedCcmiVH47mz1kI4gWHco=
+github.com/dolthub/dolt/go v0.40.5-0.20260828012016-eb949f4275a9 h1:LoSfUhwT9JpbzGNny8/cAfRIVJtVKtztrHdGSyqT9FY=
+github.com/dolthub/dolt/go v0.40.5-0.20260828012016-eb949f4275a9/go.mod h1:LfsOnHLbroYX8R6k1c5QcwedCcmiVH47mz1kI4gWHco=
 github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4 h1:0mg9QEFdkkBwJMxvz1tCjHYmfG2iIC6aShj1InDq9/M=
 github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=


### PR DESCRIPTION
Auto-bump of `dolt` to `eb949f4275a9a7de69e43ccf6e42493d7f4af27e` (triggered via `repository_dispatch`).

- This PR was created automatically.
- Older auto-bump PRs for the same dependency may be auto-closed if their CI is complete and acceptable.