### PR TITLE
[auto-bump] dolt @ fae1715c

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/dolthub/dolt/go v0.40.5-0.20260902090248-362a86528a8a
+	github.com/dolthub/dolt/go v0.40.5-0.20260902151307-fae1715c7f33
 	github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260901230631-da4d8ec733de
 	github.com/dolthub/vitess v0.0.0-20260901210329-5364bf844382

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 h1:I
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12/go.mod h1:rN7X8BHwkjPcfMQQ2QTAq/xM3leUSGLfb+1Js7Y6TVo=
 github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP44=
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
-github.com/dolthub/dolt/go v0.40.5-0.20260902090248-362a86528a8a h1:UYVUJAvh6+MvTA0Uu/OT0JAjJiwujbvgdG2mOb5izuw=
-github.com/dolthub/dolt/go v0.40.5-0.20260902090248-362a86528a8a/go.mod h1:uf/ksQZrkSUWBkIPnU+ULo6Gdn7UKEcR5I+Z+aJ6yT8=
+github.com/dolthub/dolt/go v0.40.5-0.20260902151307-fae1715c7f33 h1:Yxn/Fwol2UiX36vwuwEMkJbNslKU9ZbN6VH10nfyCj4=
+github.com/dolthub/dolt/go v0.40.5-0.20260902151307-fae1715c7f33/go.mod h1:uf/ksQZrkSUWBkIPnU+ULo6Gdn7UKEcR5I+Z+aJ6yT8=
 github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4 h1:0mg9QEFdkkBwJMxvz1tCjHYmfG2iIC6aShj1InDq9/M=
 github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=


### PR DESCRIPTION
Auto-bump of `dolt` to `fae1715c7f33900a483e2c4c3eef37bb649df684` (triggered via `repository_dispatch`).

- This PR was created automatically.
- Older auto-bump PRs for the same dependency may be auto-closed if their CI is complete and acceptable.